### PR TITLE
Fix issue #2

### DIFF
--- a/script.js
+++ b/script.js
@@ -4645,7 +4645,6 @@ class UIDesigner {
         // Clear current design
         this.elements.clear();
         this.selectedElement = null;
-        this.canvas.innerHTML = '';
 
         // Set framework
         this.currentFramework = project.framework;
@@ -4755,7 +4754,7 @@ class UIDesigner {
             }
         });
         this.updateElementPalette();
-        this.updateLogoAndTitle();
+        // this.updateLogoAndTitle(); Not defined. Causes an uncaught error.
     }
 
     // Show notification


### PR DESCRIPTION
Setting the canvas's innerHTML to '' likely caused problems where assigning to divs within it was not working properly. I do not have the knowledge to really say exactly what was going on though.

Additionally, UIDesigner#updateFrameworkTab was trying to make a call to UIDesigner#updateLogoAndTitle, which doesn't exist. Within the loadProject function that calls UIDesigner#updateFrameworkTab(), this would cause an uncaught error that would prevent the rest of the code from executing.